### PR TITLE
Fix deprecated Hugo variable use

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -39,3 +39,9 @@ rel = "manifest"
 [mediaTypes."text/netlify"]
 delimiter = ""
 suffixes = [""]
+[taxonomies]
+  category = "categories"
+  tag = "tags"
+  author = "authors"
+  social = "social"
+


### PR DESCRIPTION
## Summary
- declare social and author taxonomies in Hugo config

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688a7c08c17c8332b830449ed875b666