### PR TITLE
Fix deprecations in SEO partial

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -84,7 +84,9 @@ enableQQ = false # https://valine.js.org/en/configuration.html#enableQQ
 keywords = ["Copper", "Hugo", "Gethugothemes", "Themefisher"]
 description = "This is meta description"
 author = "Gethugothemes"
-image = "images/logo.png"                                       
+twitter_site = ""
+twitter_creator = ""
+image = "images/logo.png"
 # this image will be used as fallback if a page has no image of its own
 
 # matomo tracking: see https://matomo.org/

--- a/layouts/partials/basic-seo.html
+++ b/layouts/partials/basic-seo.html
@@ -1,0 +1,172 @@
+<!-- base url -->
+{{ if or (eq site.BaseURL "/") (eq site.BaseURL "http://localhost:1313/") (eq site.BaseURL "http://examplesite.org/") (eq site.BaseURL "https://examplesite.org/") (eq site.BaseURL "http://examplesite.com/") (eq site.BaseURL "https://examplesite.com/") }}
+{{ else }}
+  <base href="{{ .Permalink }}" />
+{{ end }}
+
+
+<!-- meta noindex -->
+{{ if .Params.noindex }}
+  <meta name="robots" content="noindex,nofollow" />
+{{ end }}
+
+
+<!-- meta canonical -->
+<link rel="canonical" href="{{ .Permalink }}" itemprop="url" />
+
+<!-- multilingual SEO optimizations -->
+{{ if .IsTranslated }}
+  {{ range .AllTranslations }}
+    <link rel="alternate" hreflang="{{ .Lang }}" href="{{ .Permalink }}" />
+  {{ end }}
+  <link rel="alternate" hreflang="x-default" href="{{ .Permalink }}" />
+{{ end }}
+
+
+<!-- meta keywords -->
+{{ if .Params.keywords }}
+  <meta name="keywords" content="{{ delimit .Params.keywords `, ` }}" />
+{{ else if site.Params.metadata.keywords }}
+  <meta
+    name="keywords"
+    content="{{ delimit site.Params.metadata.keywords `, ` }}" />
+{{ end }}
+
+
+<!-- meta description -->
+<meta
+  name="description"
+  content="{{ .Params.description | default site.Params.metadata.description }}" />
+
+<!-- meta author -->
+{{ with site.Params.metadata.author }}
+  <meta name="author" content="{{ . }}" />
+{{ end }}
+
+
+<!-- meta hugo version -->
+{{ hugo.Generator }}
+
+
+<!-- checking og title -->
+{{ $title := site.Title }}
+{{ if .Params.og_title }}
+  {{ $title = .Params.og_title }}
+  <!-- checking page title -->
+{{ else if .Title }}
+  {{ $title = .Title }}
+  <!-- checking metadata title -->
+{{ else if site.Params.metadata.title }}
+  {{ $title = site.Params.metadata.title }}
+{{ end }}
+
+
+<!-- checking og description -->
+{{ $description := .Summary }}
+{{ if .Params.og_description }}
+  {{ $description = .Params.og_description }}
+  <!-- checking page description -->
+{{ else if .Params.description }}
+  {{ $description = .Params.description }}
+  <!-- checking page description -->
+{{ else if site.Params.metadata.description }}
+  {{ $description = site.Params.metadata.description }}
+{{ end }}
+
+
+<!-- checking og image -->
+{{ $imagePath := site.Params.metadata.image }}
+{{ if .Params.og_image }}
+  {{ $imagePath = .Params.og_image }}
+  <!-- checking multiple images -->
+{{ else if .Params.images }}
+  {{ range first 1 .Params.images }}
+    {{ $imagePath = . }}
+  {{ end }}
+  <!-- checking single images -->
+{{ else if .Params.image }}
+  {{ $imagePath = .Params.image }}
+{{ end }}
+
+
+<!-- ######### Opengraph and Twitter image meta ############## -->
+
+<!-- check cdn/static image -->
+{{ if or (hasPrefix $imagePath "http") (fileExists (add `static/` (string $imagePath))) }}
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="{{ $imagePath | absURL }}" />
+  <meta property="og:image" content="{{ $imagePath | absURL }}" />
+{{ else }}
+  <!-- check cdn/static image -->
+
+  <!-- content and assets image path variable -->
+  {{ $contentImage:= .Resources.GetMatch (printf "*%s*" $imagePath) }}
+  {{ $assetImage:= fileExists (add `assets/` (string $imagePath)) }}
+
+
+  <!-- check image existence -->
+  {{ if or $contentImage $assetImage }}
+    <!-- content or assets folder detection -->
+    {{ if $contentImage }}
+      {{ .Scratch.Set "image-exists" $contentImage }}
+    {{ else if $assetImage }}
+      {{ .Scratch.Set "image-exists" (resources.Get $imagePath) }}
+    {{ end }}
+
+    {{ $image:= .Scratch.Get "image-exists" }}
+
+
+    <!-- image extension -->
+    {{ $imageExt:= path.Ext $image }}
+
+
+    <!-- If not SVG  -->
+    {{ if ne $imageExt `.svg` }}
+      {{ $imageWidth := $image.Width }}
+      {{ $imageHeight := $image.Height }}
+      {{ if (and (gt $imageWidth 144) (gt $imageHeight 144)) }}
+        <meta property="og:image" content="{{ $image.Permalink }}" />
+        <meta name="twitter:image" content="{{ $image.Permalink }}" />
+        <meta
+          name="twitter:card"
+          content="summary{{ if (and (gt $imageWidth 300) (gt $imageHeight 157) (not (eq $imageWidth $imageHeight))) }}
+            _large_image
+          {{ end }}" />
+      {{ end }}
+      <!-- /if image gt 144px -->
+      <meta property="og:image:width" content="{{ $imageWidth }}" />
+      <meta property="og:image:height" content="{{ $imageHeight }}" />
+    {{ end }}
+
+    <!-- /if not svg -->
+
+    <meta
+      property="og:image:type"
+      content="image/{{ if eq $imageExt `.svg` }}
+        svg+xml
+      {{ else }}
+        {{ replaceRE `^jpg$` `jpeg` $imageExt }}
+      {{ end }}" />
+  {{ end }}
+
+  <!-- /if image exist -->
+{{ end }}
+<!-- /check cdn/static image -->
+<!-- ######### /Opengraph and Twitter image meta ############## -->
+
+<!-- ######### opengraph others meta ############## -->
+<meta property="og:title" content="{{ $title }}" />
+<meta property="og:description" content="{{ $description }}" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="{{ .Permalink }}" />
+
+<!-- ########## twitter others meta ############### -->
+<meta name="twitter:title" content="{{ $title }}" />
+<meta name="twitter:description" content="{{ $description }}" />
+
+{{ with site.Params.metadata.twitter_site }}
+  <meta name="twitter:site" content="@{{ . }}" />
+{{ end }}
+{{ with site.Params.metadata.twitter_creator }}
+  <meta name="twitter:creator" content="@{{ . }}" />
+{{ end }}


### PR DESCRIPTION
## Summary
- override `basic-seo.html` partial to remove deprecated `.Site` fields
- expose `twitter_site` and `twitter_creator` params

## Testing
- `npm test` *(fails: `hugo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7c08c17c8332b830449ed875b666