### PR TITLE
Fix duplicate auth buttons

### DIFF
--- a/static/user-menu.js
+++ b/static/user-menu.js
@@ -3,12 +3,18 @@ const netlifyIdentity = window.netlifyIdentity;
 function updateUserMenu(user) {
   const menu = document.getElementById('user-menu');
   const name = document.getElementById('user-name');
+  const loginBtn = document.getElementById('login-btn');
+  const signupBtn = document.getElementById('signup-btn');
   if (!menu || !name) return;
   if (user) {
     name.textContent = user.user_metadata && user.user_metadata.full_name ? user.user_metadata.full_name : user.email;
     menu.classList.remove('d-none');
+    if (loginBtn) loginBtn.style.display = 'none';
+    if (signupBtn) signupBtn.style.display = 'none';
   } else {
     menu.classList.add('d-none');
+    if (loginBtn) loginBtn.style.display = '';
+    if (signupBtn) signupBtn.style.display = '';
   }
 }
 

--- a/themes/copper-hugo/layouts/partials/essential/header.html
+++ b/themes/copper-hugo/layouts/partials/essential/header.html
@@ -81,7 +81,6 @@
           <div>
           
           
-          <div data-netlify-identity-menu></div>
 
           <div class="dropdown d-none" id="user-menu">
             <a class="btn btn-sm btn-outline-primary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
@@ -97,14 +96,14 @@
           
           {{ with site.Params.navigation_button_bordered}}
           {{ if .enable }}
-          <a {{if .link}}href="{{.link | relLangURL}}" {{else}}data-bs-toggle="modal" data-bs-target="#signup-modal"
+          <a id="signup-btn" {{if .link}}href="{{.link | relLangURL}}" {{else}}data-bs-toggle="modal" data-bs-target="#signup-modal"
             {{end}} class="btn btn-sm btn-outline-primary">{{ .label }}</a>
           {{ end }}
           {{ end }}
 
           {{ with site.Params.navigation_button_linked}}
           {{ if .enable }}
-          <a {{if .link}}href="{{.link | relLangURL}}" {{else}} data-bs-toggle="modal" data-bs-target="#signin-modal"
+          <a id="login-btn" {{if .link}}href="{{.link | relLangURL}}" {{else}} data-bs-toggle="modal" data-bs-target="#signin-modal"
             {{end}} class="btn btn-sm btn-link pe-xl-0">{{ .label }}<svg width="1.5em" height="1.5em"
               viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor"
               xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- remove Netlify Identity menu placeholder that created extra login/signup buttons
- mark signup and login buttons with IDs
- hide auth buttons once user logs in

## Testing
- `go test ./...` *(no packages to test)*
- `hugo --minify` *(failed: command not found)*
- `apt-get update` *(failed: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688a813a2b7c833289f7cad45a319785