### PR TITLE
Enable sign in and sign up buttons

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -39,13 +39,13 @@ greetings_to = "CGM"
 
 # Navigation button
 [navigation_button_bordered]
-enable = false
+enable = true
 label = "Sign Up"
 link = ""
 
 # Navigation button
 [navigation_button_linked]
-enable = false
+enable = true
 label = "Log In"
 link = ""
 


### PR DESCRIPTION
## Summary
- enable sign up and login navbar buttons via params config

## Testing
- `npm test` *(fails: `hugo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a85257098833289de86045cf31acb