### PR TITLE
Add profile editing page

### DIFF
--- a/content/english/profile/index.html
+++ b/content/english/profile/index.html
@@ -1,0 +1,17 @@
+---
+title: "User Profile"
+layout: "regular"
+---
+
+<div id="profile-page" class="container py-5">
+  <p id="welcome-message" class="h5"></p>
+  <form id="profile-form" style="display:none;" class="mt-4">
+    <div class="form-group mb-3">
+      <label for="full-name" class="h6">Full Name</label>
+      <input id="full-name" type="text" class="form-control shadow-none" />
+    </div>
+    <button type="submit" class="btn btn-primary">Update Profile</button>
+  </form>
+</div>
+
+<script src="/profile.js" defer></script>

--- a/static/profile.js
+++ b/static/profile.js
@@ -1,0 +1,40 @@
+// File: static/profile.js
+// Handles showing and updating user profile via Netlify Identity
+
+function initProfile() {
+  const identity = window.netlifyIdentity;
+  const msg = document.getElementById('welcome-message');
+  const form = document.getElementById('profile-form');
+  const nameInput = document.getElementById('full-name');
+
+  if (!identity || !msg || !form || !nameInput) return;
+
+  const user = identity.currentUser();
+  if (user) {
+    msg.textContent = `Logged in as ${user.email}`;
+    nameInput.value = user.user_metadata && user.user_metadata.full_name ? user.user_metadata.full_name : '';
+    form.style.display = 'block';
+  } else {
+    msg.textContent = 'Please log in to edit your profile.';
+    form.style.display = 'none';
+  }
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const newName = nameInput.value;
+    const currentUser = identity.currentUser();
+    if (!currentUser) return;
+    currentUser.update({ data: { full_name: newName } })
+      .then(function(updated) {
+        msg.textContent = `Profile updated for ${updated.email}`;
+      })
+      .catch(function(err) {
+        alert(err.message || 'Profile update failed');
+      });
+  });
+
+  identity.on('login', () => location.reload());
+  identity.on('logout', () => location.reload());
+}
+
+document.addEventListener('DOMContentLoaded', initProfile);


### PR DESCRIPTION
## Summary
- add `profile` page
- add JS for editing user profile with Netlify Identity

## Testing
- `npm test` *(fails: `hugo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a93aa98188332b6d096b0613e70d8