### PR TITLE
Fix secret exposures

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -1,5 +1,5 @@
 ######################## default configuration ####################
-baseURL = "https://cgmx.org/"
+baseURL = "/"
 title = "CGM"
 theme = "copper-hugo"
 # post pagination

--- a/layouts/cgmdoc.html
+++ b/layouts/cgmdoc.html
@@ -24,6 +24,7 @@
 
   <!-- Auth0 widget script -->
   <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  {{ partial "auth0-config.html" }}
   <script src="/auth0-init.js"></script>
 
   <!-- Your custom JavaScript -->

--- a/layouts/partials/auth0-config.html
+++ b/layouts/partials/auth0-config.html
@@ -1,0 +1,4 @@
+<script>
+window.AUTH0_DOMAIN = '{{ getenv "AUTH0_DOMAIN" }}';
+window.AUTH0_CLIENT_ID = '{{ getenv "AUTH0_CLIENT_ID" }}';
+</script>

--- a/layouts/partials/essential/header.html
+++ b/layouts/partials/essential/header.html
@@ -1,6 +1,7 @@
 {{ "<!-- navigation -->" | safeHTML }}
 <!-- Auth0 widget script -->
  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+ {{ partial "auth0-config.html" }}
  <script src="{{ "auth0-init.js" | relURL }}"></script>
  
 <header class="header-nav position-relative {{.Scratch.Get `bg`}}" data-aos="fade-in">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,5 +1,6 @@
 {{ "<!-- navigation -->" | safeHTML }}
 <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+{{ partial "auth0-config.html" }}
 <script src="{{ "auth0-init.js" | relURL }}"></script>
 <script src="{{ "Navbar.js" | relURL }}"></script>
 

--- a/static/auth0-init.js
+++ b/static/auth0-init.js
@@ -1,7 +1,7 @@
 window.auth0 = null;
 window.auth0ClientPromise = createAuth0Client({
-  domain: 'dev-bm83wa86bo4gmb4x.auth0.com',
-  client_id: 'dAlXWEe7JLEgOTsV3LgKLHnWspb91Ozo',
+  domain: window.AUTH0_DOMAIN,
+  client_id: window.AUTH0_CLIENT_ID,
   cacheLocation: 'localstorage'
 }).then(client => {
   window.auth0 = client;


### PR DESCRIPTION
## Summary
- remove hardcoded Auth0 credentials
- configure scripts to read Auth0 values from environment variables
- use root-relative baseURL to avoid exposing domain in config

## Testing
- `hugo --minify --gc` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b9013c3408332b7ee3f31ec13db5e