### PR TITLE
Fix Hugo build by allowing Auth0 env vars

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -45,3 +45,8 @@ suffixes = [""]
   author = "authors"
   social = "social"
 
+########################### Security ############################
+[security]
+  [security.funcs]
+    getenv = ['^HUGO_', '^AUTH0_']
+


### PR DESCRIPTION
## Summary
- permit Auth0 environment variables

## Testing
- `npm run build` *(fails: hugo not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b92920f2c8332ad5905db4bcca6ae