### PR TITLE
Add Auth0 callback support

### DIFF
--- a/content/chinese/callback/index.html
+++ b/content/chinese/callback/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="zh">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Auth0 Callback</title>
+  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script src="/auth0-init.js"></script>
+  <script src="/callback.js"></script>
+</head>
+<body>
+  <p>\u767b\u5f55\u5904\u7406\u4e2d...</p>
+</body>
+</html>

--- a/content/chinese/testlogin/index.html
+++ b/content/chinese/testlogin/index.html
@@ -97,7 +97,11 @@
                 if (d > exp){
                 console.log("Your session has expired")
                 auth0.logout({ returnTo: window.location.href });
-                auth0.loginWithRedirect();
+                auth0.loginWithRedirect({
+                    authorizationParams: {
+                        redirect_uri: window.location.origin + '/callback/'
+                    }
+                });
                 } else {
                 console.log("the token hasn't expired, yet")
                 updateLoginText()
@@ -108,7 +112,11 @@
                 if (user) {
                     updateLoginText();
                 } else {
-                    document.getElementById('auth0-login-btn').addEventListener('click', () => auth0.loginWithRedirect());
+                    document.getElementById('auth0-login-btn').addEventListener('click', () => auth0.loginWithRedirect({
+                        authorizationParams: {
+                            redirect_uri: window.location.origin + '/callback/'
+                        }
+                    }));
                 }
             })();
             

--- a/content/english/callback/index.html
+++ b/content/english/callback/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Auth0 Callback</title>
+  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script src="/auth0-init.js"></script>
+  <script src="/callback.js"></script>
+</head>
+<body>
+  <p>Processing login...</p>
+</body>
+</html>

--- a/static/auth0-init.js
+++ b/static/auth0-init.js
@@ -4,19 +4,10 @@ window.auth0ClientPromise = createAuth0Client({
   client_id: window.AUTH0_CLIENT_ID,
   cacheLocation: 'localstorage',
   authorizationParams: {
-    redirect_uri: window.location.origin,
+    // Redirect back to the dedicated callback page after login
+    redirect_uri: window.location.origin + '/callback/',
   },
-}).then(async (client) => {
+}).then((client) => {
   window.auth0 = client;
-  // Handle the login redirect from Auth0
-  if (window.location.search.includes('code=') &&
-      window.location.search.includes('state=')) {
-    try {
-      await client.handleRedirectCallback();
-      window.history.replaceState({}, document.title, window.location.pathname);
-    } catch (err) {
-      console.error('Auth0 callback error', err);
-    }
-  }
   return client;
 });

--- a/static/callback.js
+++ b/static/callback.js
@@ -1,0 +1,15 @@
+window.addEventListener('DOMContentLoaded', async () => {
+  const client = await window.auth0ClientPromise;
+  if (window.location.search.includes('code=') &&
+      window.location.search.includes('state=')) {
+    try {
+      const { appState } = await client.handleRedirectCallback();
+      const target = (appState && appState.targetUrl) || '/homepage';
+      window.location.replace(target);
+    } catch (err) {
+      console.error('Auth0 callback processing failed', err);
+    }
+  } else {
+    window.location.replace('/homepage');
+  }
+});

--- a/static/gated.js
+++ b/static/gated.js
@@ -12,7 +12,8 @@
     loginBtn.addEventListener('click', async () => {
       await auth0.loginWithRedirect({
         authorizationParams: {
-          redirect_uri: window.location.origin
+          // Send users to the Auth0 callback page after authentication
+          redirect_uri: window.location.origin + '/callback/'
         }
       });
     });


### PR DESCRIPTION
## Summary
- route `/callback/` for Auth0 redirects (English and Chinese)
- handle Auth0 OAuth response and redirect
- send login requests to the callback path

## Testing
- `npm test` *(fails: `hugo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688bca173d988332984f0055f03f121d