### PR TITLE
Fix Auth0 login redirect for older SDK

### DIFF
--- a/content/chinese/testlogin/index.html
+++ b/content/chinese/testlogin/index.html
@@ -98,9 +98,7 @@
                 console.log("Your session has expired")
                 auth0.logout({ returnTo: window.location.href });
                 auth0.loginWithRedirect({
-                    authorizationParams: {
-                        redirect_uri: window.location.origin + '/callback/'
-                    }
+                    redirect_uri: window.location.origin + '/callback/'
                 });
                 } else {
                 console.log("the token hasn't expired, yet")
@@ -113,9 +111,7 @@
                     updateLoginText();
                 } else {
                     document.getElementById('auth0-login-btn').addEventListener('click', () => auth0.loginWithRedirect({
-                        authorizationParams: {
-                            redirect_uri: window.location.origin + '/callback/'
-                        }
+                        redirect_uri: window.location.origin + '/callback/'
                     }));
                 }
             })();

--- a/layouts/partials/essential/header.html
+++ b/layouts/partials/essential/header.html
@@ -99,14 +99,14 @@
           
           {{ with site.Params.navigation_button_bordered}}
           {{ if .enable }}
-          <a id="signup-btn" href="#" onclick="auth0 && auth0.loginWithRedirect({screen_hint: 'signup', authorizationParams: {redirect_uri: window.location.origin + '/callback/'}}); return false;"
+          <a id="signup-btn" href="#" onclick="auth0 && auth0.loginWithRedirect({screen_hint: 'signup', redirect_uri: window.location.origin + '/callback/'}); return false;"
             class="btn btn-sm btn-outline-primary">{{ .label }}</a>
           {{ end }}
           {{ end }}
 
           {{ with site.Params.navigation_button_linked}}
           {{ if .enable }}
-          <a id="login-btn" href="#" onclick="auth0 && auth0.loginWithRedirect({authorizationParams: {redirect_uri: window.location.origin + '/callback/'}}); return false;"
+          <a id="login-btn" href="#" onclick="auth0 && auth0.loginWithRedirect({redirect_uri: window.location.origin + '/callback/'}); return false;"
             class="btn btn-sm btn-link pe-xl-0">{{ .label }}<svg width="1.5em" height="1.5em"
               viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor"
               xmlns="http://www.w3.org/2000/svg">

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -79,8 +79,8 @@
       
         
           <div class="navbar-button">
-            <button onclick="auth0 && auth0.loginWithRedirect({authorizationParams: {redirect_uri: window.location.origin + '/callback/'}})">Log in</button>
-            <button onclick="auth0 && auth0.loginWithRedirect({screen_hint: 'signup', authorizationParams: {redirect_uri: window.location.origin + '/callback/'}})">Sign up</button>
+            <button onclick="auth0 && auth0.loginWithRedirect({redirect_uri: window.location.origin + '/callback/'})">Log in</button>
+            <button onclick="auth0 && auth0.loginWithRedirect({screen_hint: 'signup', redirect_uri: window.location.origin + '/callback/'})">Sign up</button>
           
           <!-- 
           {{ with site.Params.navigation_button_bordered}}

--- a/static/auth0-init.js
+++ b/static/auth0-init.js
@@ -3,10 +3,8 @@ window.auth0ClientPromise = createAuth0Client({
   domain: window.AUTH0_DOMAIN,
   client_id: window.AUTH0_CLIENT_ID,
   cacheLocation: 'localstorage',
-  authorizationParams: {
-    // Redirect back to the dedicated callback page after login
-    redirect_uri: window.location.origin + '/callback/',
-  },
+  // Redirect back to the dedicated callback page after login
+  redirect_uri: window.location.origin + '/callback/',
 }).then((client) => {
   window.auth0 = client;
   return client;

--- a/static/gated.js
+++ b/static/gated.js
@@ -11,10 +11,8 @@
   if (loginBtn) {
     loginBtn.addEventListener('click', async () => {
       await auth0.loginWithRedirect({
-        authorizationParams: {
-          // Send users to the Auth0 callback page after authentication
-          redirect_uri: window.location.origin + '/callback/'
-        }
+        // Send users to the Auth0 callback page after authentication
+        redirect_uri: window.location.origin + '/callback/'
       });
     });
   }


### PR DESCRIPTION
## Summary
- fix auth0 login parameters to work with older SPA JS SDK

## Testing
- `npm run test` *(fails: hugo not found)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688bdb42a754833297098b0901ac515a