### PR TITLE
Fix Auth0 callback rendering

### DIFF
--- a/content/chinese/callback/index.html
+++ b/content/chinese/callback/index.html
@@ -1,15 +1,5 @@
-<!doctype html>
-<html lang="zh">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Auth0 Callback</title>
-  {{ partial "auth0-config.html" }}
-  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
-  <script src="/auth0-init.js"></script>
-  <script src="/callback.js"></script>
-</head>
-<body>
-  <p>\u767b\u5f55\u5904\u7406\u4e2d...</p>
-</body>
-</html>
+---
+title: "Auth0 Callback"
+layout: "callback"
+---
+<p>登录处理中...</p>

--- a/content/english/callback/index.html
+++ b/content/english/callback/index.html
@@ -1,15 +1,5 @@
-<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Auth0 Callback</title>
-  {{ partial "auth0-config.html" }}
-  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
-  <script src="/auth0-init.js"></script>
-  <script src="/callback.js"></script>
-</head>
-<body>
-  <p>Processing login...</p>
-</body>
-</html>
+---
+title: "Auth0 Callback"
+layout: "callback"
+---
+<p>Processing login...</p>

--- a/layouts/callback.html
+++ b/layouts/callback.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="{{ .Site.Language.Lang }}">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Auth0 Callback</title>
+  {{ partial "auth0-config.html" }}
+  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
+  <script src="/auth0-init.js"></script>
+  <script src="/callback.js"></script>
+</head>
+<body>
+  {{ .Content }}
+</body>
+</html>

--- a/static/callback.js
+++ b/static/callback.js
@@ -6,12 +6,12 @@ window.addEventListener('DOMContentLoaded', async () => {
       const { appState } = await client.handleRedirectCallback();
       // remove code and state query parameters to keep URL clean
       window.history.replaceState({}, document.title, '/');
-      const target = (appState && appState.targetUrl) || '/homepage';
+      const target = (appState && appState.targetUrl) || '/';
       window.location.replace(target);
     } catch (err) {
       console.error('Auth0 callback processing failed', err);
     }
   } else {
-    window.location.replace('/homepage');
+    window.location.replace('/');
   }
 });


### PR DESCRIPTION
## Summary
- render callback page as a Hugo template
- create custom callback layout
- redirect to site root after login

## Testing
- `npm test` *(fails: hugo not found)*
- `apt-get update` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688be103a0a8833291c666444fd277e1