### PR TITLE
Improve callback page login flow

### DIFF
--- a/layouts/callback.html
+++ b/layouts/callback.html
@@ -1,15 +1,16 @@
-<!doctype html>
-<html lang="{{ .Site.Language.Lang }}">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Auth0 Callback</title>
-  {{ partial "auth0-config.html" }}
-  <script src="https://cdn.auth0.com/js/auth0-spa-js/1.19/auth0-spa-js.production.js"></script>
-  <script src="/auth0-init.js"></script>
-  <script src="/callback.js"></script>
-</head>
-<body>
-  {{ .Content }}
-</body>
+<!DOCTYPE html>
+<html lang="{{ site.LanguageCode | default `en-US` }}">
+  <head>
+    {{ partial "essential/head.html" . }}
+    {{ partialCached "essential/style.html" . }}
+  </head>
+  <body>
+    {{ partial "essential/header.html" . }}
+    <main>
+      {{ .Content }}
+    </main>
+    {{ partial "essential/footer.html" . }}
+    {{ partialCached "essential/script.html" . }}
+    <script src="/callback.js"></script>
+  </body>
 </html>

--- a/static/callback.js
+++ b/static/callback.js
@@ -4,6 +4,7 @@ window.addEventListener('DOMContentLoaded', async () => {
       window.location.search.includes('state=')) {
     try {
       const { appState } = await client.handleRedirectCallback();
+      updateUserMenu(await client.getUser());
       // remove code and state query parameters to keep URL clean
       window.history.replaceState({}, document.title, '/');
       const target = (appState && appState.targetUrl) || '/';


### PR DESCRIPTION
## Summary
- include site header in the callback layout so user info can be shown
- update callback script to refresh user menu after login

## Testing
- `npm test` *(fails: `hugo: not found`)*
- `npm run build` *(fails: `hugo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688be2f16df88332a01f58e3fe50a673