### PR TITLE
Handle Auth0 callback on dedicated page

### DIFF
--- a/content/chinese/callback/index.html
+++ b/content/chinese/callback/index.html
@@ -2,4 +2,5 @@
 title: "Auth0 Callback"
 layout: "callback"
 ---
-<p>登录处理中...</p>
+<p id="callback-status">登录处理中...</p>
+<div id="user-info"></div>

--- a/content/english/callback/index.html
+++ b/content/english/callback/index.html
@@ -2,4 +2,5 @@
 title: "Auth0 Callback"
 layout: "callback"
 ---
-<p>Processing login...</p>
+<p id="callback-status">Processing login...</p>
+<div id="user-info"></div>

--- a/static/callback.js
+++ b/static/callback.js
@@ -3,12 +3,12 @@ window.addEventListener('DOMContentLoaded', async () => {
   if (window.location.search.includes('code=') &&
       window.location.search.includes('state=')) {
     try {
-      const { appState } = await client.handleRedirectCallback();
-      updateUserMenu(await client.getUser());
+      await client.handleRedirectCallback();
+      const user = await client.getUser();
+      updateUserMenu(user);
       // remove code and state query parameters to keep URL clean
-      window.history.replaceState({}, document.title, '/');
-      const target = (appState && appState.targetUrl) || '/';
-      window.location.replace(target);
+      window.history.replaceState({}, document.title, window.location.pathname);
+      displayUserInfo(user);
     } catch (err) {
       console.error('Auth0 callback processing failed', err);
     }
@@ -16,3 +16,10 @@ window.addEventListener('DOMContentLoaded', async () => {
     window.location.replace('/');
   }
 });
+
+function displayUserInfo(user) {
+  const container = document.getElementById("user-info");
+  if (!container || !user) return;
+  container.innerHTML = `<h2>Welcome, ${user.name || user.email}</h2>\n<pre>${JSON.stringify(user, null, 2)}</pre>`;
+}
+


### PR DESCRIPTION
## Summary
- display user information on the callback page
- show the dropdown menu once login completes

## Testing
- `timeout 10 npm test` *(fails: cd: can't cd to exampleSite; hugo not found)*

------
https://chatgpt.com/codex/tasks/task_e_688be55d5d888332be4d625043158dde