### PR TITLE
Fix user menu script path

### DIFF
--- a/layouts/partials/essential/header.html
+++ b/layouts/partials/essential/header.html
@@ -118,7 +118,7 @@
           
           </div>
 
-          <script src="/user-menu.js" defer></script>
+          <script src="{{ "user-menu.js" | relURL }}" defer></script>
 
       </div>
       <!-- nav links -->

--- a/static/user-menu.js
+++ b/static/user-menu.js
@@ -1,18 +1,18 @@
 async function updateUserMenu(user) {
   const menu = document.getElementById('user-menu');
   const name = document.getElementById('user-name');
-  const loginBtn = document.getElementById('login-btn');
-  const signupBtn = document.getElementById('signup-btn');
+  const loginBtns = document.querySelectorAll('#login-btn');
+  const signupBtns = document.querySelectorAll('#signup-btn');
   if (!menu || !name) return;
   if (user) {
     name.textContent = user.name || user.email || 'User';
     menu.classList.remove('d-none');
-    if (loginBtn) loginBtn.style.display = 'none';
-    if (signupBtn) signupBtn.style.display = 'none';
+    loginBtns.forEach((el) => (el.style.display = 'none'));
+    signupBtns.forEach((el) => (el.style.display = 'none'));
   } else {
     menu.classList.add('d-none');
-    if (loginBtn) loginBtn.style.display = '';
-    if (signupBtn) signupBtn.style.display = '';
+    loginBtns.forEach((el) => (el.style.display = ''));
+    signupBtns.forEach((el) => (el.style.display = ''));
   }
 }
 

--- a/themes/copper-hugo/layouts/partials/essential/header.html
+++ b/themes/copper-hugo/layouts/partials/essential/header.html
@@ -117,7 +117,7 @@
           
           </div>
 
-          <script src="/user-menu.js" defer></script>
+          <script src="{{ "user-menu.js" | relURL }}" defer></script>
 
       </div>
       <!-- nav links -->


### PR DESCRIPTION
## Summary
- fix user menu path in header partials so script loads relative to baseURL
- hide multiple login/signup buttons if present

## Testing
- `npm test` *(fails: hugo not found)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688c194adc608332aa5c060b0feaa26e