### PR TITLE
Improve Auth0 scripts

### DIFF
--- a/static/auth0-init.js
+++ b/static/auth0-init.js
@@ -1,11 +1,28 @@
-window.auth0 = null;
-window.auth0ClientPromise = createAuth0Client({
-  domain: window.AUTH0_DOMAIN,
-  client_id: window.AUTH0_CLIENT_ID,
-  cacheLocation: 'localstorage',
-  // Redirect back to the dedicated callback page after login
-  redirect_uri: window.location.origin + '/callback/',
-}).then((client) => {
-  window.auth0 = client;
-  return client;
-});
+(function () {
+  const fallback = window._env_ || {};
+  const domain = window.AUTH0_DOMAIN || fallback.AUTH0_DOMAIN;
+  const clientId = window.AUTH0_CLIENT_ID || fallback.AUTH0_CLIENT_ID;
+
+  if (!domain || !clientId) {
+    console.error(
+      "Missing Auth0 configuration: AUTH0_DOMAIN or AUTH0_CLIENT_ID"
+    );
+    return;
+  }
+
+  window.auth0ClientPromise = createAuth0Client({
+    domain,
+    client_id: clientId,
+    cacheLocation: "localstorage",
+    redirect_uri: window.location.origin + "/callback/",
+  })
+    .then((client) => {
+      window.auth0 = client;
+      window.dispatchEvent(new Event("auth0-ready"));
+      return client;
+    })
+    .catch((err) => {
+      console.error("Error initializing Auth0:", err);
+      throw err;
+    });
+})();

--- a/static/user-menu.js
+++ b/static/user-menu.js
@@ -1,31 +1,42 @@
 async function updateUserMenu(user) {
-  const menu = document.getElementById('user-menu');
-  const name = document.getElementById('user-name');
-  const loginBtns = document.querySelectorAll('#login-btn');
-  const signupBtns = document.querySelectorAll('#signup-btn');
+  const menu = document.getElementById("user-menu");
+  const name = document.getElementById("user-name");
+  const loginBtns = document.querySelectorAll("#login-btn");
+  const signupBtns = document.querySelectorAll("#signup-btn");
   if (!menu || !name) return;
   if (user) {
-    name.textContent = user.name || user.email || 'User';
-    menu.classList.remove('d-none');
-    loginBtns.forEach((el) => (el.style.display = 'none'));
-    signupBtns.forEach((el) => (el.style.display = 'none'));
+    name.textContent = user.name || user.email || "User";
+    menu.classList.remove("d-none");
+    loginBtns.forEach((el) => (el.style.display = "none"));
+    signupBtns.forEach((el) => (el.style.display = "none"));
   } else {
-    menu.classList.add('d-none');
-    loginBtns.forEach((el) => (el.style.display = ''));
-    signupBtns.forEach((el) => (el.style.display = ''));
+    menu.classList.add("d-none");
+    loginBtns.forEach((el) => (el.style.display = ""));
+    signupBtns.forEach((el) => (el.style.display = ""));
   }
 }
 
-document.addEventListener('DOMContentLoaded', async function () {
-  const auth0 = await window.auth0ClientPromise;
-  updateUserMenu(await auth0.getUser());
+document.addEventListener("DOMContentLoaded", function () {
+  const start = async () => {
+    try {
+      const auth0 = await window.auth0ClientPromise;
+      updateUserMenu(await auth0.getUser());
+      const logoutBtn = document.getElementById("logout-btn");
+      if (logoutBtn) {
+        logoutBtn.addEventListener("click", async function (e) {
+          e.preventDefault();
+          await auth0.logout({ returnTo: window.location.origin });
+          updateUserMenu(null);
+        });
+      }
+    } catch (err) {
+      console.error("Unable to initialize user menu:", err);
+    }
+  };
 
-  const logoutBtn = document.getElementById('logout-btn');
-  if (logoutBtn) {
-    logoutBtn.addEventListener('click', async function (e) {
-      e.preventDefault();
-      await auth0.logout({ returnTo: window.location.origin });
-      updateUserMenu(null);
-    });
+  if (window.auth0ClientPromise) {
+    start();
+  } else {
+    window.addEventListener("auth0-ready", start);
   }
 });


### PR DESCRIPTION
## Summary
- enhance Auth0 initialization with fallback config and error handling
- add loading state and error handling to callback page
- ensure user menu waits for Auth0 client before operating

## Testing
- `npx prettier -w static/auth0-init.js static/callback.js static/user-menu.js`
- `npm test` *(fails: `hugo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688c1fc7fffc833290631593808320bb