### PR TITLE
Fix header auth handling

### DIFF
--- a/layouts/partials/essential/header.html
+++ b/layouts/partials/essential/header.html
@@ -81,44 +81,46 @@
         
         
           <div>
-          
-          
-          <!-- Netlify Identity widget menu removed to avoid duplicate buttons -->
 
-          <div class="dropdown d-none" id="user-menu">
-            <a class="btn btn-sm btn-outline-primary dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-              <span id="user-name">User</span>
-            </a>
-            <ul class="dropdown-menu dropdown-menu-end">
-              <li><a class="dropdown-item" href="/profile/">Profile</a></li>
-              <li><a class="dropdown-item" href="/faq/">Manu</a></li>
-              <li><a class="dropdown-item" href="/services/">Services</a></li>
-              <li><a class="dropdown-item" href="#" id="logout-btn">Log out</a></li>
-            </ul>
+            <!-- Loading indicator -->
+            <div id="auth-loading" style="display:none" class="spinner-border spinner-border-sm me-2" role="status"></div>
+
+            <!-- Buttons shown when not authenticated -->
+            <div id="auth-buttons" class="navbar-button d-flex gap-2">
+              {{ with site.Params.navigation_button_bordered}}
+              {{ if .enable }}
+              <a id="signup-btn" href="#" class="btn btn-sm btn-outline-primary">{{ .label }}</a>
+              {{ end }}
+              {{ end }}
+
+              {{ with site.Params.navigation_button_linked}}
+              {{ if .enable }}
+              <a id="login-btn" href="#" class="btn btn-sm btn-link pe-xl-0">{{ .label }}<svg width="1.5em" height="1.5em"
+                  viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg">
+                  <path fill-rule="evenodd"
+                    d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z" />
+                </svg></a>
+              {{ end }}
+              {{ end }}
+            </div>
+
+            <!-- Dropdown shown when authenticated -->
+            <div class="dropdown d-none" id="user-menu" style="display:none;">
+              <a class="btn btn-sm btn-outline-primary dropdown-toggle" href="#" id="user-dropdown-btn" role="button" aria-expanded="false">
+                <span id="user-name">User</span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-end" id="user-dropdown">
+                <li><a class="dropdown-item" href="/profile/">Profile</a></li>
+                <li><a class="dropdown-item" href="/faq/">Manu</a></li>
+                <li><a class="dropdown-item" href="/services/">Services</a></li>
+                <li><a class="dropdown-item" href="#" id="logout-btn">Log out</a></li>
+              </ul>
+            </div>
+
+            <script src="{{ "header-auth.js" | relURL }}" defer></script>
+
           </div>
-          
-          {{ with site.Params.navigation_button_bordered}}
-          {{ if .enable }}
-          <a id="signup-btn" href="#" onclick="auth0 && auth0.loginWithRedirect({screen_hint: 'signup', redirect_uri: window.location.origin + '/callback/'}); return false;"
-            class="btn btn-sm btn-outline-primary">{{ .label }}</a>
-          {{ end }}
-          {{ end }}
-
-          {{ with site.Params.navigation_button_linked}}
-          {{ if .enable }}
-          <a id="login-btn" href="#" onclick="auth0 && auth0.loginWithRedirect({redirect_uri: window.location.origin + '/callback/'}); return false;"
-            class="btn btn-sm btn-link pe-xl-0">{{ .label }}<svg width="1.5em" height="1.5em"
-              viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor"
-              xmlns="http://www.w3.org/2000/svg">
-              <path fill-rule="evenodd"
-                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z" />
-            </svg></a>
-          {{ end }}
-          {{ end }}
-          
-          </div>
-
-          <script src="{{ "user-menu.js" | relURL }}" defer></script>
 
       </div>
       <!-- nav links -->

--- a/static/auth0-init.js
+++ b/static/auth0-init.js
@@ -19,6 +19,7 @@
     .then((client) => {
       window.auth0 = client;
       window.dispatchEvent(new Event("auth0-ready"));
+      window.dispatchEvent(new Event("auth0Ready"));
       return client;
     })
     .catch((err) => {

--- a/static/header-auth.js
+++ b/static/header-auth.js
@@ -1,0 +1,207 @@
+console.log('🔧 Initializing header authentication...');
+class HeaderAuth {
+  constructor() {
+    this.isInitialized = false;
+    this.currentUser = null;
+    this.elements = {};
+    this.init();
+  }
+  async init() {
+    // Get DOM elements
+    this.elements = {
+      authLoading: document.getElementById('auth-loading'),
+      authButtons: document.getElementById('auth-buttons'),
+      userMenu: document.getElementById('user-menu'),
+      userName: document.getElementById('user-name'),
+      loginBtn: document.getElementById('login-btn'),
+      signupBtn: document.getElementById('signup-btn'),
+      logoutBtn: document.getElementById('logout-btn'),
+      userDropdownBtn: document.getElementById('user-dropdown-btn')
+    };
+    // Show loading state
+    this.showLoading();
+    try {
+      // Wait for Auth0 to be ready
+      const auth0Client = await window.auth0ClientPromise;
+      console.log('✅ Auth0 client ready');
+      // Check authentication status
+      await this.checkAuthStatus(auth0Client);
+      // Set up event listeners
+      this.setupEventListeners(auth0Client);
+      this.isInitialized = true;
+      console.log('✅ Header auth initialized');
+    } catch (error) {
+      console.error('❌ Header auth initialization failed:', error);
+      this.showError();
+    }
+  }
+  async checkAuthStatus(auth0Client) {
+    try {
+      const isAuthenticated = await auth0Client.isAuthenticated();
+      if (isAuthenticated) {
+        const user = await auth0Client.getUser();
+        this.updateUIForUser(user);
+      } else {
+        // Check if we just came back from callback
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('code') && urlParams.has('state')) {
+          // We're on a callback - wait a moment for processing
+          setTimeout(async () => {
+            const user = await auth0Client.getUser();
+            if (user) {
+              this.updateUIForUser(user);
+            } else {
+              this.updateUIForGuest();
+            }
+          }, 1000);
+        } else {
+          this.updateUIForGuest();
+        }
+      }
+    } catch (error) {
+      console.error('Error checking auth status:', error);
+      this.updateUIForGuest();
+    }
+  }
+  updateUIForUser(user) {
+    console.log('👤 User authenticated:', user?.email);
+    this.currentUser = user;
+    // Hide loading and auth buttons
+    this.hideLoading();
+    if (this.elements.authButtons) {
+      this.elements.authButtons.style.display = 'none';
+    }
+    // Show user menu
+    if (this.elements.userMenu) {
+      this.elements.userMenu.style.display = 'block';
+      this.elements.userMenu.classList.remove('d-none');
+    }
+    // Update user name
+    if (this.elements.userName && user) {
+      this.elements.userName.textContent = user.name || user.email || 'User';
+    }
+  }
+  updateUIForGuest() {
+    console.log('👤 User not authenticated');
+    this.currentUser = null;
+    // Hide loading and user menu
+    this.hideLoading();
+    if (this.elements.userMenu) {
+      this.elements.userMenu.style.display = 'none';
+      this.elements.userMenu.classList.add('d-none');
+    }
+    // Show auth buttons
+    if (this.elements.authButtons) {
+      this.elements.authButtons.style.display = 'flex';
+    }
+  }
+  setupEventListeners(auth0Client) {
+    // Login button
+    if (this.elements.loginBtn) {
+      this.elements.loginBtn.addEventListener('click', async (e) => {
+        e.preventDefault();
+        this.showLoading();
+        // Store current page to return to after login
+        sessionStorage.setItem('auth0_return_to', window.location.pathname);
+        try {
+          await auth0Client.loginWithRedirect({
+            authorizationParams: {
+              redirect_uri: window.location.origin + '/callback/'
+            }
+          });
+        } catch (error) {
+          console.error('Login failed:', error);
+          this.hideLoading();
+        }
+      });
+    }
+    // Signup button
+    if (this.elements.signupBtn) {
+      this.elements.signupBtn.addEventListener('click', async (e) => {
+        e.preventDefault();
+        this.showLoading();
+        sessionStorage.setItem('auth0_return_to', window.location.pathname);
+        try {
+          await auth0Client.loginWithRedirect({
+            authorizationParams: {
+              redirect_uri: window.location.origin + '/callback/',
+              screen_hint: 'signup'
+            }
+          });
+        } catch (error) {
+          console.error('Signup failed:', error);
+          this.hideLoading();
+        }
+      });
+    }
+    // Logout button
+    if (this.elements.logoutBtn) {
+      this.elements.logoutBtn.addEventListener('click', async (e) => {
+        e.preventDefault();
+        this.showLoading();
+        try {
+          await auth0Client.logout({
+            logoutParams: { returnTo: window.location.origin }
+          });
+        } catch (error) {
+          console.error('Logout failed:', error);
+          // Force logout by clearing localStorage and redirecting
+          localStorage.clear();
+          window.location.href = '/';
+        }
+      });
+    }
+    // User dropdown toggle
+    if (this.elements.userDropdownBtn) {
+      this.elements.userDropdownBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        const dropdown = document.getElementById('user-dropdown');
+        if (dropdown) {
+          dropdown.classList.toggle('show');
+        }
+      });
+    }
+    // Close dropdown when clicking outside
+    document.addEventListener('click', (e) => {
+      if (!e.target.closest('#user-menu')) {
+        const dropdown = document.getElementById('user-dropdown');
+        if (dropdown) {
+          dropdown.classList.remove('show');
+        }
+      }
+    });
+  }
+  showLoading() {
+    if (this.elements.authLoading) {
+      this.elements.authLoading.style.display = 'block';
+    }
+    if (this.elements.authButtons) {
+      this.elements.authButtons.style.display = 'none';
+    }
+  }
+  hideLoading() {
+    if (this.elements.authLoading) {
+      this.elements.authLoading.style.display = 'none';
+    }
+  }
+  showError() {
+    this.hideLoading();
+    console.error('Auth system unavailable');
+    // Could show a message to user here if needed
+  }
+}
+// Initialize when DOM is ready
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    new HeaderAuth();
+  });
+} else {
+  new HeaderAuth();
+}
+// Also listen for Auth0 ready event as backup
+window.addEventListener('auth0Ready', () => {
+  if (!window.headerAuth || !window.headerAuth.isInitialized) {
+    window.headerAuth = new HeaderAuth();
+  }
+});
+


### PR DESCRIPTION
## Summary
- improve Auth0 init event dispatch
- overhaul header partial for better auth handling
- add a new `header-auth.js` script to manage auth UI

## Testing
- `npm test` *(fails: `sh: 1: hugo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688c246a1f248332ab27b89b95d9b590