### PR TITLE
Redirect to dashboard after profile

### DIFF
--- a/content/english/dashboard/index.html
+++ b/content/english/dashboard/index.html
@@ -1,0 +1,5 @@
+---
+title: "User Dashboard"
+layout: "dashboard"
+---
+<p>Welcome to your dashboard.</p>

--- a/layouts/page/profile.html
+++ b/layouts/page/profile.html
@@ -72,6 +72,7 @@
           messageEl.classList.remove("d-none", "alert-danger");
           messageEl.classList.add("alert-success");
           messageEl.textContent = "✅ Profile updated successfully.";
+          window.location.href = "/dashboard/";
         } else {
           messageEl.classList.remove("d-none", "alert-success");
           messageEl.classList.add("alert-danger");

--- a/layouts/partials/essential/header.html
+++ b/layouts/partials/essential/header.html
@@ -189,7 +189,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         if (elements.loginBtn) {
             elements.loginBtn.addEventListener('click', async (e) => {
                 e.preventDefault();
-                sessionStorage.setItem('auth0_return_to', window.location.pathname);
+                sessionStorage.setItem('auth0_return_to', '/profile/');
                 await auth0Client.loginWithRedirect({
                     authorizationParams: {
                         redirect_uri: window.location.origin + '/callback/'
@@ -201,7 +201,7 @@ document.addEventListener('DOMContentLoaded', async function() {
         if (elements.signupBtn) {
             elements.signupBtn.addEventListener('click', async (e) => {
                 e.preventDefault();
-                sessionStorage.setItem('auth0_return_to', window.location.pathname);
+                sessionStorage.setItem('auth0_return_to', '/profile/');
                 await auth0Client.loginWithRedirect({
                     authorizationParams: {
                         redirect_uri: window.location.origin + '/callback/',

--- a/static/profile.js
+++ b/static/profile.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', async function () {
   if (!form) return;
   form.addEventListener('submit', function (e) {
     e.preventDefault();
-    alert('Profile updated (example)');
+    alert('Profile updated');
+    window.location.href = '/dashboard/';
   });
 });


### PR DESCRIPTION
## Summary
- set login redirect to profile page
- redirect profile form submission to dashboard
- create profile layout redirect when save
- add simple dashboard page

## Testing
- `npm test` *(fails: hugo not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d1003e2d083329ad275c9c977e009