### PR TITLE
Show first paragraph for blog lists

### DIFF
--- a/themes/copper-hugo/layouts/_default/list.html
+++ b/themes/copper-hugo/layouts/_default/list.html
@@ -33,7 +33,9 @@
             <div class="post-meta font-weight-600 mb-15">{{.PublishDate.Format "02 Jan, 2006"}}<span
                 class="mx-2">|</span>{{ .Page.ReadingTime }} {{ i18n "minute_read" }}
             </div>
-            <p>{{ .Summary }}</p>
+            {{ with (findRE "(?sU)<p>.*</p>" .Content 1) }}
+            {{ index . 0 | safeHTML }}
+            {{ end }}
           </div>
         </div>
         <!-- blog-post item -->


### PR DESCRIPTION
## Summary
- Display only the first paragraph of each post in blog listings

## Testing
- `npm test` *(fails: cd: can't cd to exampleSite; hugo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d77cb01708332b5f9fb3bff1655c5